### PR TITLE
Fixed live emotion prediction from defaulting to 'angry'

### DIFF
--- a/emotion.py
+++ b/emotion.py
@@ -1,6 +1,5 @@
 import cv2
 from deepface import DeepFace
-import numpy as np
 
 # Load face cascade classifier
 face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
@@ -46,3 +45,4 @@ while True:
 # Release the capture and close all windows
 cap.release()
 cv2.destroyAllWindows()
+

--- a/emotion.py
+++ b/emotion.py
@@ -2,9 +2,6 @@ import cv2
 from deepface import DeepFace
 import numpy as np
 
-# Define emotion labels
-emotion_labels = ['angry', 'disgust', 'fear', 'happy', 'sad', 'surprise', 'neutral']
-
 # Load face cascade classifier
 face_cascade = cv2.CascadeClassifier(cv2.data.haarcascades + 'haarcascade_frontalface_default.xml')
 
@@ -31,7 +28,6 @@ while True:
         
         # Perform emotion analysis on the face ROI
         result = DeepFace.analyze(face_roi, actions=['emotion'], enforce_detection=False)
-        # print(result)
 
         # Determine the dominant emotion
         emotion = result[0]['dominant_emotion']

--- a/emotion.py
+++ b/emotion.py
@@ -1,8 +1,6 @@
 import cv2
 from deepface import DeepFace
-
-# Load the pre-trained emotion detection model
-model = DeepFace.build_model("Emotion")
+import numpy as np
 
 # Define emotion labels
 emotion_labels = ['angry', 'disgust', 'fear', 'happy', 'sad', 'surprise', 'neutral']
@@ -20,26 +18,23 @@ while True:
     # Convert frame to grayscale
     gray_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
 
+    # Convert grayscale frame to RGB format
+    rgb_frame = cv2.cvtColor(gray_frame, cv2.COLOR_GRAY2RGB)
+
     # Detect faces in the frame
     faces = face_cascade.detectMultiScale(gray_frame, scaleFactor=1.1, minNeighbors=5, minSize=(30, 30))
 
     for (x, y, w, h) in faces:
         # Extract the face ROI (Region of Interest)
-        face_roi = gray_frame[y:y + h, x:x + w]
+        face_roi = rgb_frame[y:y + h, x:x + w]
 
-        # Resize the face ROI to match the input shape of the model
-        resized_face = cv2.resize(face_roi, (48, 48), interpolation=cv2.INTER_AREA)
+        
+        # Perform emotion analysis on the face ROI
+        result = DeepFace.analyze(face_roi, actions=['emotion'], enforce_detection=False)
+        # print(result)
 
-        # Normalize the resized face image
-        normalized_face = resized_face / 255.0
-
-        # Reshape the image to match the input shape of the model
-        reshaped_face = normalized_face.reshape(1, 48, 48, 1)
-
-        # Predict emotions using the pre-trained model
-        preds = model.predict(reshaped_face)[0]
-        emotion_idx = preds.argmax()
-        emotion = emotion_labels[emotion_idx]
+        # Determine the dominant emotion
+        emotion = result[0]['dominant_emotion']
 
         # Draw rectangle around face and label with predicted emotion
         cv2.rectangle(frame, (x, y), (x + w, y + h), (0, 0, 255), 2)


### PR DESCRIPTION
This pull request fixes an issue with the live emotion prediction feature, which was defaulting to 'angry' regardless of the actual prediction.  

Changes Made 
1. Modified the code to correctly extract and display the dominant emotion prediction through the use of the DeepFace.analyze() function. 
3. Removed redundant code that was causing the defaulting behavior.